### PR TITLE
Feature/v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # vue-logger-plugin changelog
 
+## [2.2.2] - 2022-03-02
+* Update logging functions (`log`, `error`, `warn`, `info`, `debug`) to no longer return a promise.
+    * Still supports asynchronous run function in hooks
+    * Fix for [Issue 26](https://github.com/dev-tavern/vue-logger-plugin/issues/26)
+
 ## [2.2.1] - 2022-02-09
 
 * Add caller function information support for Firefox browser
@@ -70,6 +75,7 @@
     * built-in argument stringify hooks
     * on-demand log level adjustment and enable/disable via `apply`
 
+[2.2.2]: https://github.com/dev-tavern/vue-logger-plugin/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/dev-tavern/vue-logger-plugin/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/dev-tavern/vue-logger-plugin/compare/v2.1.4...v2.2.0
 [2.1.4]: https://github.com/dev-tavern/vue-logger-plugin/compare/v2.1.3...v2.1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-logger-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-logger-plugin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Flexible logging functionality for Vue.js 2 & 3",
   "author": "Josh Gamble",
   "license": "MIT",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -36,24 +36,34 @@ export class VueLogger {
     this.installHooks(this._options.afterHooks)
   }
 
-  async debug(...args: any): Promise<void> {
-    await this.invoke('debug', ...args)
+  debug(...args: any): void {
+    this.invoke('debug', ...args)
+    .then(() => {/*intentinonal empty*/})
+    .catch(() => {/*intentinonal empty*/})
   }
 
-  async info(...args: any): Promise<void> {
-    await this.invoke('info', ...args)
+  info(...args: any): void {
+    this.invoke('info', ...args)
+    .then(() => {/*intentinonal empty*/})
+    .catch(() => {/*intentinonal empty*/})
   }
 
-  async warn(...args: any): Promise<void> {
-    await this.invoke('warn', ...args)
+  warn(...args: any): void {
+    this.invoke('warn', ...args)
+    .then(() => {/*intentinonal empty*/})
+    .catch(() => {/*intentinonal empty*/})
   }
 
-  async error(...args: any): Promise<void> {
-    await this.invoke('error', ...args)
+  error(...args: any): void {
+    this.invoke('error', ...args)
+    .then(() => {/*intentinonal empty*/})
+    .catch(() => {/*intentinonal empty*/})
   }
 
-  async log(...args: any): Promise<void> {
-    await this.invoke('log', ...args)
+  log(...args: any): void {
+    this.invoke('log', ...args)
+    .then(() => {/*intentinonal empty*/})
+    .catch(() => {/*intentinonal empty*/})
   }
 
   private async invoke(level: LogLevel, ...args: any) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -38,32 +38,32 @@ export class VueLogger {
 
   debug(...args: any): void {
     this.invoke('debug', ...args)
-      .then(() => {/*intentinonal empty*/})
-      .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentional empty*/})
+      .catch(() => {/*intentional empty*/})
   }
 
   info(...args: any): void {
     this.invoke('info', ...args)
-      .then(() => {/*intentinonal empty*/})
-      .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentional empty*/})
+      .catch(() => {/*intentional empty*/})
   }
 
   warn(...args: any): void {
     this.invoke('warn', ...args)
-      .then(() => {/*intentinonal empty*/})
-      .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentional empty*/})
+      .catch(() => {/*intentional empty*/})
   }
 
   error(...args: any): void {
     this.invoke('error', ...args)
-      .then(() => {/*intentinonal empty*/})
-      .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentional empty*/})
+      .catch(() => {/*intentional empty*/})
   }
 
   log(...args: any): void {
     this.invoke('log', ...args)
-      .then(() => {/*intentinonal empty*/})
-      .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentional empty*/})
+      .catch(() => {/*intentional empty*/})
   }
 
   private async invoke(level: LogLevel, ...args: any) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -38,20 +38,20 @@ export class VueLogger {
 
   debug(...args: any): void {
     this.invoke('debug', ...args)
-    .then(() => {/*intentinonal empty*/})
-    .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentinonal empty*/})
+      .catch(() => {/*intentinonal empty*/})
   }
 
   info(...args: any): void {
     this.invoke('info', ...args)
-    .then(() => {/*intentinonal empty*/})
-    .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentinonal empty*/})
+      .catch(() => {/*intentinonal empty*/})
   }
 
   warn(...args: any): void {
     this.invoke('warn', ...args)
-    .then(() => {/*intentinonal empty*/})
-    .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentinonal empty*/})
+      .catch(() => {/*intentinonal empty*/})
   }
 
   error(...args: any): void {
@@ -62,8 +62,8 @@ export class VueLogger {
 
   log(...args: any): void {
     this.invoke('log', ...args)
-    .then(() => {/*intentinonal empty*/})
-    .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentinonal empty*/})
+      .catch(() => {/*intentinonal empty*/})
   }
 
   private async invoke(level: LogLevel, ...args: any) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -56,8 +56,8 @@ export class VueLogger {
 
   error(...args: any): void {
     this.invoke('error', ...args)
-    .then(() => {/*intentinonal empty*/})
-    .catch(() => {/*intentinonal empty*/})
+      .then(() => {/*intentinonal empty*/})
+      .catch(() => {/*intentinonal empty*/})
   }
 
   log(...args: any): void {

--- a/src/types/logger.d.ts
+++ b/src/types/logger.d.ts
@@ -40,7 +40,7 @@ export declare class VueLogger {
    *
    * @param args
    */
-  debug (...args: any): Promise<void>
+  debug (...args: any): void
   /**
    * Perform info level logging.
    *
@@ -48,7 +48,7 @@ export declare class VueLogger {
    *
    * @param args
    */
-  info (...args: any): Promise<void>
+  info (...args: any): void
   /**
    * Perform warning level logging.
    *
@@ -56,7 +56,7 @@ export declare class VueLogger {
    *
    * @param args
    */
-  warn (...args: any): Promise<void>
+  warn (...args: any): void
   /**
    * Perform error level logging.
    *
@@ -64,7 +64,7 @@ export declare class VueLogger {
    *
    * @param args
    */
-  error (...args: any): Promise<void>
+  error (...args: any): void
   /**
    * Perform generic (console.log) level logging.
    *
@@ -72,7 +72,7 @@ export declare class VueLogger {
    *
    * @param args
    */
-  log (...args: any): Promise<void>
+  log (...args: any): void
   /**
    * Returns whether logging is enabled.
    */

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -14,40 +14,45 @@ describe('logging: levels', () => {
 
   it('debug logs to console.debug', async () => {
     console.debug = jest.fn()
-    await VueE.config.globalProperties.$log.debug('test')
-    await VueE.config.globalProperties.$log.debug('test', testObject)
+    VueE.config.globalProperties.$log.debug('test')
+    VueE.config.globalProperties.$log.debug('test', testObject)
+    await new Promise(process.nextTick)
     expect(console.debug).toHaveBeenCalledWith('[DEBUG]', 'test')
     expect(console.debug).toHaveBeenCalledWith('[DEBUG]', 'test', testObject)
   })
 
   it('info logs to console.info', async () => {
     console.info = jest.fn()
-    await VueE.config.globalProperties.$log.info('test')
-    await VueE.config.globalProperties.$log.info('test', testObject)
+    VueE.config.globalProperties.$log.info('test')
+    VueE.config.globalProperties.$log.info('test', testObject)
+    await new Promise(process.nextTick)
     expect(console.info).toHaveBeenCalledWith('[INFO]', 'test')
     expect(console.info).toHaveBeenCalledWith('[INFO]', 'test', testObject)
   })
 
   it('warn logs to console.warn', async () => {
     console.warn = jest.fn()
-    await VueE.config.globalProperties.$log.warn('test')
-    await VueE.config.globalProperties.$log.warn('test', testObject)
+    VueE.config.globalProperties.$log.warn('test')
+    VueE.config.globalProperties.$log.warn('test', testObject)
+    await new Promise(process.nextTick)
     expect(console.warn).toHaveBeenCalledWith('[WARN]', 'test')
     expect(console.warn).toHaveBeenCalledWith('[WARN]', 'test', testObject)
   })
 
   it('error logs to console.error', async () => {
     console.error = jest.fn()
-    await VueE.config.globalProperties.$log.error('test')
-    await VueE.config.globalProperties.$log.error('test', testObject)
+    VueE.config.globalProperties.$log.error('test')
+    VueE.config.globalProperties.$log.error('test', testObject)
+    await new Promise(process.nextTick)
     expect(console.error).toHaveBeenCalledWith('[ERROR]', 'test')
     expect(console.error).toHaveBeenCalledWith('[ERROR]', 'test', testObject)
   })
 
   it('log logs to console.log', async () => {
     console.log = jest.fn()
-    await VueE.config.globalProperties.$log.log('test')
-    await VueE.config.globalProperties.$log.log('test', testObject)
+    VueE.config.globalProperties.$log.log('test')
+    VueE.config.globalProperties.$log.log('test', testObject)
+    await new Promise(process.nextTick)
     expect(console.log).toHaveBeenCalledWith('[LOG]', 'test')
     expect(console.log).toHaveBeenCalledWith('[LOG]', 'test', testObject)
   })
@@ -64,7 +69,8 @@ describe('logging: unsupported', () => {
     console.warn = undefined
     console.log = jest.fn()
     const logger = createLogger()
-    await logger.warn('test')
+    logger.warn('test')
+    await new Promise(process.nextTick)
     expect(console.log).toHaveBeenCalledWith('[WARN]', 'test')
   })
 
@@ -81,7 +87,8 @@ describe('logging: hooks', () => {
       run: jest.fn()
     }
     const logger = createLogger({ beforeHooks: [hook] })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(hook.run).toHaveBeenCalledWith(
       expect.objectContaining({
         level: 'log',
@@ -95,7 +102,8 @@ describe('logging: hooks', () => {
       run: jest.fn()
     }
     const logger = createLogger({ afterHooks: [hook] })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(hook.run).toHaveBeenCalledWith(
       expect.objectContaining({
         level: 'log',
@@ -111,7 +119,8 @@ describe('logging: hooks', () => {
     }
     hook.run.mockImplementation(() => { throw Error('Test') })
     const logger = createLogger({ beforeHooks: [hook] })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(console.warn).toHaveBeenCalledWith(
       'LoggerHook run failure',
       expect.anything()
@@ -129,7 +138,8 @@ describe('logging: disabled', () => {
   it('does not write to console', async () => {
     console.log = jest.fn()
     const logger = createLogger({ enabled: false })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(console.log).not.toHaveBeenCalled()
   })
 
@@ -139,7 +149,8 @@ describe('logging: disabled', () => {
       run: jest.fn()
     }
     const logger = createLogger({ enabled: false, beforeHooks: [hook] })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(hook.run).not.toHaveBeenCalled()
   })
 
@@ -154,7 +165,8 @@ describe('logging: console disabled', () => {
   it('does not write to console', async () => {
     console.log = jest.fn()
     const logger = createLogger({ consoleEnabled: false })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(console.log).not.toHaveBeenCalled()
   })
 
@@ -164,7 +176,8 @@ describe('logging: console disabled', () => {
       run: jest.fn()
     }
     const logger = createLogger({ consoleEnabled: false, beforeHooks: [hook] })
-    await logger.log('test')
+    logger.log('test')
+    await new Promise(process.nextTick)
     expect(hook.run).toHaveBeenCalled()
   })
 
@@ -179,7 +192,8 @@ describe('logging: prefix format', () => {
   it('uses custom format when provided', async () => {
     console.debug = jest.fn()
     const logger = createLogger({ prefixFormat: ({ level }) => `[${level.toUpperCase()}]` })
-    await logger.debug('test')
+    logger.debug('test')
+    await new Promise(process.nextTick)
     expect(console.debug).toHaveBeenCalledWith('[DEBUG]', 'test')
   })
 
@@ -195,22 +209,24 @@ describe('logging: caller info', () => {
     jest.restoreAllMocks()
   })
 
-  async function doLog(logger) {
-    await logger.debug('test')
+  function doLog(logger) {
+    logger.debug('test')
   }
 
   it('logs caller info', async () => {
     console.debug = jest.fn()
     const logger = createLogger({ callerInfo: true })
-    await doLog(logger)
-    expect(console.debug).toHaveBeenCalledWith('[DEBUG] [logging.test.ts:doLog:199]', 'test')
+    doLog(logger)
+    await new Promise(process.nextTick)
+    expect(console.debug).toHaveBeenCalledWith('[DEBUG] [logging.test.ts:doLog:213]', 'test')
   })
 
   it('does not log caller info when stack unavailable', async () => {
     const mockErrorStack = jest.spyOn(window.Error, 'prepareStackTrace') as any
     mockErrorStack.mockImplementation(() => undefined)
     const logger = createLogger({ callerInfo: true })
-    await doLog(logger)
+    doLog(logger)
+    await new Promise(process.nextTick)
     expect(console.debug).toHaveBeenCalledWith('[DEBUG]', 'test')
   })
 


### PR DESCRIPTION
* Update logging functions (`log`, `error`, `warn`, `info`, `debug`) to no longer return a promise.
    * Still supports asynchronous run function in hooks
    * Fix for [Issue 26](https://github.com/dev-tavern/vue-logger-plugin/issues/26)